### PR TITLE
修复部分应用在启动前存在进程通信空指针BUG

### DIFF
--- a/BCore/src/main/java/top/niunaijun/bcore/fake/service/IActivityManagerProxy.java
+++ b/BCore/src/main/java/top/niunaijun/bcore/fake/service/IActivityManagerProxy.java
@@ -416,7 +416,9 @@ public class IActivityManagerProxy extends ClassInvocationStub {
 
             Intent proxyIntent = BlackBoxCore.getBActivityManager().sendBroadcast(intent, resolvedType, BActivityThread.getUserId());
             if (proxyIntent != null) {
-                proxyIntent.setExtrasClassLoader(BActivityThread.getApplication().getClassLoader());
+                if (BActivityThread.getApplication() != null) {
+                    proxyIntent.setExtrasClassLoader(BActivityThread.getApplication().getClassLoader());
+                }
 
                 ProxyBroadcastRecord.saveStub(proxyIntent, intent, BActivityThread.getUserId());
                 args[intentIndex] = proxyIntent;


### PR DESCRIPTION
发现微信在makeApplication时就开始发广播，导致启动失败，可能是微信使用了Tinker热修复插件导致的。
见issue：https://github.com/Monster-GM/NewBlackbox/issues/2